### PR TITLE
enable source maps and bump traceur version

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,11 +29,14 @@ module.exports = function(sails) {
         sails.log.verbose("Traceur hook deactivated.");
       } else {
 
-        //Load Traceur and override the default require; with async/await on.
+        /**
+         * Load Traceur and override the default require; with async/await on.
+         * Enable inline source maps to be able to debug warnings/errors correctly.
+         */
         require('traceur').require.makeDefault(function(filename) {
           // don't transpile our dependencies, just our app
           return filename.indexOf('node_modules') === -1;
-        }, { asyncFunctions: true });
+        }, { asyncFunctions: true, sourceMaps: 'inline' });
 
         sails.log.verbose("Traceur hook activated. Enjoy ES6/7 power in your Sails app.");
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "isHook": true
   },
   "dependencies": {
-    "traceur": "0.0.81"
+    "traceur": "0.0.90"
   },
   "devDependencies": {
     "glob": "^4.3.2",


### PR DESCRIPTION
couldnt decide if source map generating should be configurable or not. but i just thought it should be enabled somehow.. otherwise it is almost impossible to debug failing code.. so tell me if we should do it configurable
